### PR TITLE
Update prototype-1.6.0.3.js

### DIFF
--- a/src/main/webapp/js/prototype-1.6.0.3.js
+++ b/src/main/webapp/js/prototype-1.6.0.3.js
@@ -383,7 +383,7 @@ Object.extend(String.prototype, {
   },
 
   stripTags: function() {
-    return this.replace(/<\/?[^>]+>/gi, '');
+    return this.replace(/<\/?[^>]+>?/g, '');
   },
 
   stripScripts: function() {


### PR DESCRIPTION
stripTags: strip also unterminated tags (without their trailing '>'), due to possible code injection